### PR TITLE
[FEAT] Only show future events (fixes #1)

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -24,7 +24,7 @@ description: >- # this means to ignore newlines until "baseurl:"
   Write an awesome description for your new site here. You can edit this
   line in _config.yml. It will appear in your document head meta (for
   Google search results) and in your feed.xml site description.
-baseurl: "calendar-site" 
+baseurl: "/calendar-site" 
 url: "mlh-fellowship.github.io/calendar-site" 
 
 sass:

--- a/assets/js/calendar.js
+++ b/assets/js/calendar.js
@@ -23,6 +23,8 @@ let calendarElement
 
 document.addEventListener('DOMContentLoaded', () => {
     calendarElement = document.querySelector('#calendar')
+    
+    const now = Date.now();
 
     calendar = new FullCalendar.Calendar(calendarElement, {
         plugins: ['dayGrid', 'googleCalendar', 'list', 'timeGrid'],
@@ -46,7 +48,8 @@ document.addEventListener('DOMContentLoaded', () => {
                 listDayFormat: { year: 'numeric', month: 'short', day: '2-digit', omitCommas: true },
                 listDayAltFormat: { weekday: 'long' }
             }
-        }
+        },
+        eventRender: ({ event }) => event.end.getTime() > now,
     })
     document.getElementById('timezone').innerHTML = `All times are in your local timezone! (${Intl.DateTimeFormat().resolvedOptions().timeZone})`
     calendar.render()


### PR DESCRIPTION
Keeps past events from cluttering the user's screen. (fixes #1) 